### PR TITLE
#2690159 Fix RouteNotFoundException during install

### DIFF
--- a/workspace.install
+++ b/workspace.install
@@ -16,4 +16,8 @@ function workspace_install() {
   foreach (Workspace::loadMultiple() as $workspace) {
     \Drupal::service('workspace.entity_operations')->workspaceInsert($workspace);
   }
+
+  // allow workspace entity route alterations
+  \Drupal::service('entity_type.manager')->clearCachedDefinitions();
+  \Drupal::service('router.builder')->rebuild();
 }


### PR DESCRIPTION
This module causes the error below if it is installed but caches haven't been cleared.

`NOTICE: PHP message: Uncaught PHP Exception Symfony\Component\Routing\Exception\RouteNotFoundException: "Route "entity.workspace.canonical" does not exist." at /var/www/d8platform/core/lib/Drupal/Core/Routing/RouteProvider.php line 191`

This is a problem if you're including workspace in an install profile because the cache clear doesn't happen until all the modules are done installing.

This patch resolves the issue.
