### PR TITLE
Split InternalReplicator::replicate into simpler methods

### DIFF
--- a/src/InternalReplicator.php
+++ b/src/InternalReplicator.php
@@ -93,6 +93,7 @@ class InternalReplicator implements ReplicatorInterface {
     $source_workspace = $source->getWorkspace();
     $target_workspace = $target->getWorkspace();
     // Set active workspace to source.
+    $original_workspace = $this->workspaceManager->getActiveWorkspace();
     try {
       $this->workspaceManager->setActiveWorkspace($source_workspace);
     }
@@ -149,6 +150,16 @@ class InternalReplicator implements ReplicatorInterface {
     $replication_log->setSourceLastSeq($source_workspace->getUpdateSeq());
     $replication_log->setHistory($history);
     $replication_log->save();
+
+    // return to original active workspace
+    try {
+      $this->workspaceManager->setActiveWorkspace($original_workspace);
+    }
+    catch (\Exception $e) {
+      watchdog_exception('Workspace', $e);
+      drupal_set_message($e->getMessage(), 'error');
+    }
+
     return $replication_log;
   }
 

--- a/src/InternalReplicator.php
+++ b/src/InternalReplicator.php
@@ -104,7 +104,8 @@ class InternalReplicator implements ReplicatorInterface {
     // Fetch the site time.
     $start_time = new \DateTime();
 
-    $entities = $this->diffWorkspaces($source_workspace, $target_workspace, $task);
+    $source_data = $this->listSourceChanges($source_workspace, $task);
+    $entities = $this->diffWorkspaces($source_workspace, $target_workspace, $source_data);
 
     $normal_entities = [];
     foreach ($entities as $entity) {
@@ -191,11 +192,9 @@ class InternalReplicator implements ReplicatorInterface {
   /**
    * List the entity revisions that need to be replicated
    */
-  public function diffWorkspaces(WorkspaceInterface $source_workspace, WorkspaceInterface $target_workspace, ReplicationTaskInterface $task = NULL) {
-    $data = $this->listSourceChanges($source_workspace, $task);
-
+  public function diffWorkspaces(WorkspaceInterface $source_workspace, WorkspaceInterface $target_workspace, array $source_data) {
     // Get revisions the target workspace is missing.
-    $revs_diff = $this->revisionDiffFactory->get($target_workspace)->setRevisionIds($data)->getMissing();
+    $revs_diff = $this->revisionDiffFactory->get($target_workspace)->setRevisionIds($source_data)->getMissing();
     $entities = [];
     foreach ($revs_diff as $uuid => $revs) {
       foreach ($revs['missing'] as $rev) {


### PR DESCRIPTION
I have written my own replicator as a subclass of InternalReplicator but I have a bunch of reused code in the replicate method that should be split into its own methods. 

Also, this makes the diff list actually be something other modules can consume for the purpose of showing a workspace diff UI, for example.

In doing this, I also noticed that InternalReplicator::replicate has a side-effect of switching workspaces which this PR fixes.
